### PR TITLE
Make provider and logger protected

### DIFF
--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -15,12 +15,12 @@ class RateLimiter
     /**
      * @var RateLimitProvider
      */
-    private $provider;
+    protected $provider;
 
     /**
      * @var \Psr\Log\LoggerInterface
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var string|callable Constant or callable that accepts a Response.


### PR DESCRIPTION
I want to subclass this and touch $provider but it's now allowed as `private`