### PR TITLE
Pass request object to setLastRequestTime/getLastRequestTime

### DIFF
--- a/src/RateLimitProvider.php
+++ b/src/RateLimitProvider.php
@@ -20,13 +20,13 @@ interface RateLimitProvider
      *
      * @return float|null When the last request was made.
      */
-    public function getLastRequestTime();
+    public function getLastRequestTime(RequestInterface $request);
 
     /**
      * Used to set the current time as the last request time to be queried when
      * the next request is attempted.
      */
-    public function setLastRequestTime();
+    public function setLastRequestTime(RequestInterface $request);
 
     /**
      * Returns what is considered the time when a given request is being made.

--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -61,7 +61,7 @@ class RateLimiter
 
             // Sets the time when this request is being made,
             // which allows calculation of allowance later on.
-            $this->provider->setLastRequestTime();
+            $this->provider->setLastRequestTime($request);
 
             // Set the allowance when the response was received
             return $handler($request, $options)->then($this->setAllowance());
@@ -152,7 +152,7 @@ class RateLimiter
      */
     protected function getDelay(RequestInterface $request)
     {
-        $lastRequestTime  = $this->provider->getLastRequestTime();
+        $lastRequestTime  = $this->provider->getLastRequestTime($request);
         $requestAllowance = $this->provider->getRequestAllowance($request);
         $requestTime      = $this->provider->getRequestTime($request);
 

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -62,10 +62,12 @@ class RateLimiterTest extends \PHPUnit_Framework_TestCase
 
         $provider->shouldReceive('getLastRequestTime')
                  ->once()
+                 ->with(m::type(RequestInterface::class))
                  ->andReturn($last);
 
         $provider->shouldReceive('getRequestTime')
                  ->once()
+                 ->with(m::type(RequestInterface::class))
                  ->andReturn($current);
 
         $method = $this->getMethod(RateLimiter::class, 'getDelay');
@@ -89,7 +91,7 @@ class RateLimiterTest extends \PHPUnit_Framework_TestCase
     {
         $provider = m::mock(RateLimitProvider::class);
         $provider->shouldReceive('setRequestAllowance')->once()->with(m::type(ResponseInterface::class));
-        $provider->shouldReceive('setLastRequestTime')->once();
+        $provider->shouldReceive('setLastRequestTime')->once()->with(m::type(RequestInterface::class));
 
         $promise = m::mock(PromiseInterface::class);
         $promise->shouldReceive('then')->once()->andReturnUsing(function ($a) {


### PR DESCRIPTION
I need to set/get the last request time based on some information contained in the request... an api-key in my case. This pull request adds the request as a parameter to the associated methods.
Unfortunately that's a BC break, so would require a version bump.