### PR TITLE
Fix: Add apparently missing word to docblock

### DIFF
--- a/src/RateLimitProvider.php
+++ b/src/RateLimitProvider.php
@@ -42,7 +42,7 @@ interface RateLimitProvider
      * the last request was made. This value is used to determine if the current
      * request should be delayed, based on when the last request was made.
      *
-     * Returns the allowed  between the last request and the next, which
+     * Returns the allowed time between the last request and the next, which
      * is used to determine if a request should be delayed and by how much.
      *
      * @param RequestInterface $request The pending request.


### PR DESCRIPTION
This PR

* [x] adds an apparently missing word to a docblock