### PR TITLE
Allow compatibility with guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~6.0|~7.0",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
There is no major change for rate limiting between Guzzle 6 and guzzle 7.

This PR allow to use this package with Guzzle 7